### PR TITLE
fix typo

### DIFF
--- a/ai_models_fuxi/model.py
+++ b/ai_models_fuxi/model.py
@@ -45,8 +45,8 @@ class FuXi(Model):
     download_files = [
         "short",
         "short.onnx",
-        "meidum",
-        "meidum.onnx",     
+        "medium",
+        "medium.onnx",     
         "long",
         "long.onnx",             
     ]


### PR DESCRIPTION
medium is misspelled as meidum.